### PR TITLE
🔧 MAINTAIN: tox conf: run pre-commit with --all-files flag

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands = pytest --cov={envsitepackagesdir}/mdformat_plugin {posargs}
 
 [testenv:py{36,37,38,39}-pre-commit]
 extras = dev
-commands = pre-commit run {posargs}
+commands = pre-commit run {posargs:--all-files}
 
 [testenv:py{36,37,38,39}-hook]
 extras = dev


### PR DESCRIPTION
The readme suggests that the `pre-commit` tox env is an alternative to `pre-commit run --all-files`, so I assume it should include the `--all-files` flag?

If not, then we should change
```sh
tox -e py37-pre-commit
```
to
```sh
tox -e py37-pre-commit -- --all-files
```
in the README.